### PR TITLE
Rerender with latest conda-smithy

### DIFF
--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -8,7 +8,11 @@ channel_targets:
 - nsls2forge main
 docker_image:
 - condaforge/linux-anvil-comp7
+freetype:
+- 2.9.1
 pin_run_as_build:
+  freetype:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -8,7 +8,11 @@ channel_targets:
 - nsls2forge main
 docker_image:
 - condaforge/linux-anvil-comp7
+freetype:
+- 2.9.1
 pin_run_as_build:
+  freetype:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -8,11 +8,15 @@ channel_sources:
 - nsls2forge,defaults
 channel_targets:
 - nsls2forge main
+freetype:
+- 2.9.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 pin_run_as_build:
+  freetype:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -8,11 +8,15 @@ channel_sources:
 - nsls2forge,defaults
 channel_targets:
 - nsls2forge main
+freetype:
+- 2.9.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 pin_run_as_build:
+  freetype:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/win_c_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015python3.6.yaml
@@ -4,7 +4,11 @@ channel_sources:
 - nsls2forge,defaults
 channel_targets:
 - nsls2forge main
+freetype:
+- 2.9.1
 pin_run_as_build:
+  freetype:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/win_c_compilervs2015python3.7.yaml
+++ b/.ci_support/win_c_compilervs2015python3.7.yaml
@@ -4,7 +4,11 @@ channel_sources:
 - nsls2forge,defaults
 channel_targets:
 - nsls2forge main
+freetype:
+- 2.9.1
 pin_run_as_build:
+  freetype:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<36]
 
 requirements:


### PR DESCRIPTION
It pins the `freetype` version. Let's see how it builds.